### PR TITLE
Feat standardize output

### DIFF
--- a/commands/slack.js
+++ b/commands/slack.js
@@ -1,10 +1,33 @@
 const { log, utils } = require("@boomerang-io/worker-core");
+const { CloudEvent } = require("cloudevents");
 const HttpsProxyAgent = require("https-proxy-agent");
 const { IncomingWebhook } = require("@slack/webhook");
 const { WebClient } = require("@slack/web-api");
 const axios = require("axios");
 const datetime = require("node-datetime");
 const fs = require("fs");
+
+function protectAgainstEmpty(input) {
+  if (input && typeof input === "string" && input === '""') {
+    return undefined;
+  }
+  return input;
+}
+
+function getCloudEvent(eventSubject, eventType, eventPayload) {
+  const ce = new CloudEvent({
+    source: "boomerang-io/worker.flow/slack",
+    type: eventType
+  });
+  if (protectAgainstEmpty(eventSubject)) {
+    ce["subject"] = eventSubject;
+  }
+  if (protectAgainstEmpty(eventPayload)) {
+    ce["data"] = eventPayload;
+  }
+
+  return ce;
+}
 
 // Internal Helper Functions
 async function ContentChunker(content, limit) {
@@ -570,7 +593,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-info", "SlackChannel", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -617,7 +640,7 @@ module.exports = {
       .create(data)
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-create", "SlackChannel", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -655,7 +678,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -696,7 +719,7 @@ module.exports = {
       .list(data)
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-list", "SlackChannels", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -734,7 +757,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-archive", "ActionStatus", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -772,7 +795,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-user-data", "SlackUser", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -815,7 +838,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-invite", "ActionStatus", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -858,7 +881,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(body));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-kick", "ActionStatus", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {

--- a/commands/slack.js
+++ b/commands/slack.js
@@ -678,7 +678,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
+        utils.setOutputParameter("response", getCloudEvent("slack-conversations-members", "SlackMembers", body));
         log.good("Response successfully received!");
       })
       .catch(err => {

--- a/commands/slack.js
+++ b/commands/slack.js
@@ -679,8 +679,7 @@ module.exports = {
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
         log.sys("Setting output param:", getCloudEvent("slack-conversations-members", "SlackMembers", body));
-        //utils.setOutputParameter("output", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
-        utils.setOutputParameter("output", JSON.stringify(body));
+        utils.setOutputParameter("output", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {

--- a/commands/slack.js
+++ b/commands/slack.js
@@ -113,9 +113,13 @@ module.exports = {
       if (err) {
         /** @todo Catch HTTP error for timeout so we can return better exits */
         log.err("Slack sendWebhook error", err);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-simple-message", "ActionStatus", { messageSent: "fail" })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-simple-message", "ActionStatus", { messageSent: "fail" })));
         process.exit(1);
       } else {
         log.good("Message sent: " + res.text);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-simple-message", "ActionStatus", { messageSent: "success" })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-simple-message", "ActionStatus", { messageSent: "success" })));
       }
     });
   },
@@ -167,9 +171,13 @@ module.exports = {
       if (err) {
         /** @todo Catch HTTP error for timeout so we can return better exits */
         log.err("Slack sendWebhook error", err);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-rich-message", "ActionStatus", { messageSent: "fail" })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-rich-message", "ActionStatus", { messageSent: "fail" })));
         process.exit(1);
       } else {
         log.good("Message sent: " + res.text);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-rich-message", "ActionStatus", { messageSent: "success" })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-rich-message", "ActionStatus", { messageSent: "success" })));
       }
     });
   },
@@ -306,9 +314,13 @@ module.exports = {
       if (err) {
         /** @todo Catch HTTP error for timeout so we can return better exits */
         log.err("Slack upload file error", err);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-files-message", "ActionStatus", { messageSent: "fail" })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-files-message", "ActionStatus", { messageSent: "fail" })));
         process.exit(1);
       } else {
         log.good("Message sent: " + res.text);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-files-message", "ActionStatus", { messageSent: "success" })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-files-message", "ActionStatus", { messageSent: "success" })));
       }
     });
   },
@@ -362,6 +374,8 @@ module.exports = {
 
     try {
       const response = await web.files.upload(requestConfig);
+      log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-files-upload", "ActionStatus", { slackFileUploadStatus: "success" })));
+      utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-files-upload", "ActionStatus", { slackFileUploadStatus: "success" })));
       log.debug(response);
     } catch (error) {
       log.err("Well, that was unexpected.", error);
@@ -399,7 +413,8 @@ module.exports = {
         log.debug("Response Received:", JSON.stringify(body));
         const user_id = body.user.id;
         log.sys("slackUserId Found:", user_id);
-        utils.setOutputParameter("slackUserId", user_id);
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-user-id", "SlackUser", { slackUserId: user_id })));
+        utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-files-id", "SlackUser", { slackUserId: user_id })));
         log.good("Response successfully received!");
       })
       .catch(err => {
@@ -551,7 +566,8 @@ module.exports = {
         axios
           .get(documentDownloadUrl, config)
           .then(res => {
-            utils.setOutputParameter("slackFoundDocument", res);
+            log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-files-list", "ActionStatus", { slackFoundDocument: res })));
+            utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-files-list", "ActionStatus", { slackFoundDocument: res })));
             log.good("Response successfully received!");
           })
           .catch(err => {
@@ -593,6 +609,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-info", "SlackChannel", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-info", "SlackChannel", body)));
         log.good("Response successfully received!");
       })
@@ -640,6 +657,7 @@ module.exports = {
       .create(data)
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-create", "SlackChannel", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-create", "SlackChannel", body)));
         log.good("Response successfully received!");
       })
@@ -678,7 +696,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        log.sys("Setting output param:", getCloudEvent("slack-conversations-members", "SlackMembers", body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
         utils.setOutputParameter("output", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
         log.good("Response successfully received!");
       })
@@ -720,6 +738,7 @@ module.exports = {
       .list(data)
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-list", "SlackChannels", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-list", "SlackChannels", body)));
         log.good("Response successfully received!");
       })
@@ -758,6 +777,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-archive", "ActionStatus", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-archive", "ActionStatus", body)));
         log.good("Response successfully received!");
       })
@@ -796,6 +816,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-user-data", "SlackUser", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-user-data", "SlackUser", body)));
         log.good("Response successfully received!");
       })
@@ -839,6 +860,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-invite", "ActionStatus", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-invite", "ActionStatus", body)));
         log.good("Response successfully received!");
       })
@@ -882,6 +904,7 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
+        log.sys("Setting output param:", JSON.stringify(getCloudEvent("slack-conversations-kick", "ActionStatus", body)));
         utils.setOutputParameter("response", JSON.stringify(getCloudEvent("slack-conversations-kick", "ActionStatus", body)));
         log.good("Response successfully received!");
       })

--- a/commands/slack.js
+++ b/commands/slack.js
@@ -679,7 +679,8 @@ module.exports = {
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
         log.sys("Setting output param:", getCloudEvent("slack-conversations-members", "SlackMembers", body));
-        utils.setOutputParameter("output", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
+        //utils.setOutputParameter("output", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
+        utils.setOutputParameter("output", JSON.stringify(body));
         log.good("Response successfully received!");
       })
       .catch(err => {

--- a/commands/slack.js
+++ b/commands/slack.js
@@ -678,7 +678,8 @@ module.exports = {
       })
       .then(body => {
         log.sys("Response Received:", JSON.stringify(body));
-        utils.setOutputParameter("response", getCloudEvent("slack-conversations-members", "SlackMembers", body));
+        log.sys("Setting output param:", getCloudEvent("slack-conversations-members", "SlackMembers", body));
+        utils.setOutputParameter("output", JSON.stringify(getCloudEvent("slack-conversations-members", "SlackMembers", body)));
         log.good("Response successfully received!");
       })
       .catch(err => {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@slack/web-api": "^5.8.0",
     "@slack/webhook": "^5.0.3",
     "axios": "^0.19.2",
-    "cloudevents": "^3.2.0",
     "https": "^1.0.0",
     "https-proxy-agent": "^5.0.0",
     "jsonpath": "^1.0.2",


### PR DESCRIPTION
Closes #
Standardizing the output params of the Slack tasks, moving to Cloud event structure.

Sample of the output structure,
```
{"output":"{"id":"8a79762b-8548-4619-a043-b0cd4c549078","type":"SlackMembers","source":"boomerang-io/worker.flow/slack","specversion":"1.0","time":"2021-04-12T15:41:03.931Z","data":{"ok":true,"members":["U015BUU844T","U015NP9HNMP","U015NT49ZGR"],"response_metadata":{"next_cursor":"","scopes":["incoming-webhook","users:read.email","users:read","channels:read","groups:read","im:read","mpim:read","channels:manage","groups:write","im:write","mpim:write"],"acceptedScopes":["channels:read","groups:read","mpim:read","im:read","read"]}}}"}
```

#### Changelog

**New**

- NA

**Changed**

- All exposed APIs

**Removed**

- NA

#### Testing / Reviewing


