### PR TITLE
Changing the output param to content for readFileToProperty

### DIFF
--- a/commands/file.js
+++ b/commands/file.js
@@ -111,10 +111,10 @@ module.exports = {
     log.debug("Started Read File to Property Plugin");
 
     const taskProps = utils.resolveInputParameters();
-    const { path: path, propertyName: propertyName } = taskProps;
+    const { path: path } = taskProps;
     try {
       const file = fs.readFileSync(path, "utf8");
-      await utils.setOutputParameter(propertyName, file);
+      await utils.setOutputParameter("content", file);
       log.good("The file was succesfully read!");
     } catch (e) {
       log.err(e);


### PR DESCRIPTION
Closes #

Changing the output param name to "content" for readFileToProperty

#### Changelog

**New**

- NA

**Changed**

- Modified the output content for readFileToProperty

**Removed**

- NA

#### Testing / Reviewing


