### PR TITLE
Adding a check if collaborator exist before inviting him/her

### DIFF
--- a/commands/github.js
+++ b/commands/github.js
@@ -867,12 +867,13 @@ module.exports = {
         }
       });
       octokit.hook.error("request", async error => {
+        log.debug("error.status : ", error.status);
         if (error.status === 404) {
           collaboratorExists = false;
         }
       });
       await octokit.repos.checkCollaborator(data).then(body => {
-        log.debug("Check Collaborator Response Received:", body);
+        log.debug("Check collaborator response received:", body);
       });
       log.good("Collaborator already exists: ", collaboratorExists);
       if (!collaboratorExists) {


### PR DESCRIPTION
Closes Jira ISEEC-1937

Invite Collaborator to Project is downgrading rights if the user had higher rights in the repo than being asked for.   (for example, if user has admin, and pull is sent through task, right gets downgraded).

We need to check if the user is already part of the repo and then add the user if the answer comes as 404. 

#### Changelog

**New**

- NA

**Changed**

- Invite Collaborator to Project checks for the user already in repo. 

**Removed**

- NA

#### Testing / Reviewing

Tested on the local environment
