### PR TITLE
Removing the json stringify and parse

### DIFF
--- a/commands/http.js
+++ b/commands/http.js
@@ -101,10 +101,19 @@ module.exports = {
       });
 
       res.on("end", () => {
-        const response = JSON.parse(output);
-        log.sys("Response Received:", JSON.stringify(response));
+        try {
+          //make sure non-empty output is a valid JSON,
+          //if not throw exception
+          if (!(output === null || output.match(/^ *$/) !== null)) {
+            JSON.parse(output);
+          }
+        } catch (e) {
+          log.err(e);
+          process.exit(1);
+        }
+        log.sys("Response Received:", output);
         if (outputFilePath && outputFilePath.length && outputFilePath !== '""' && outputFilePath !== '" "') {
-          fs.writeFileSync(outputFilePath, JSON.stringify(response), err => {
+          fs.writeFileSync(outputFilePath, output, err => {
             if (err) {
               log.err(err);
               throw err;
@@ -112,7 +121,7 @@ module.exports = {
             log.debug("The task output parameter successfully saved to provided file path.");
           });
         } else {
-          utils.setOutputParameter("response", JSON.stringify(response));
+          utils.setOutputParameter("response", output);
           log.debug("The task output parameter successfully saved to standard response file.");
         }
         log.good("Response successfully received!");


### PR DESCRIPTION
Closes the issue 225 raised in zenhub.

Removed the not necessary stringify and parse of JSON content and moved he validation of the non-empty responses to the very top.

#### Changelog

**New**

- Allows empty content as valid json content.

**Changed**

- NA

**Removed**

- NA

#### Testing / Reviewing

Locally, using:
 - https://httpstat.us/200  to check for valid json payload and parsing into response output
 - https://run.mocky.io/v3/8cfda2a4-0c3f-460f-a6ac-d0ccfe3b2c08 to check for http status 200 with empty body

New tag version containing the fix `2.9.5` .
