### PR TITLE
#61 wrong error casting

### DIFF
--- a/commands/http.js
+++ b/commands/http.js
@@ -200,7 +200,7 @@ module.exports = {
         }
         (async () => {
           await (async function(msg) {
-            utils.setOutputParameter("statusCode", msg?.statusCode ?? Buffer(0));
+            utils.setOutputParameter("statusCode", msg?.statusCode ?? "");
             utils.setOutputParameter("response", msg?.body?.toString() ?? msg.message);
           })(err);
           process.exit(1);

--- a/commands/http.js
+++ b/commands/http.js
@@ -160,6 +160,8 @@ module.exports = {
 
     new HTTPRetryRequest(config, reqURL, opts)
       .then(res => {
+        log.debug("res");
+        log.debug(res);
         log.debug(`statusCode: ${res.statusCode}`);
         utils.setOutputParameter("statusCode", JSON.stringify(res.statusCode));
         try {
@@ -190,11 +192,18 @@ module.exports = {
       })
       .catch(err => {
         // log.err("HTTP Promise error:", err, "Cause: ", err.cause);
-        log.err(`HTTP Promise error: \n Status Code: ${err.statusCode} \n Status Message: ${err.statusMessage} \n Response: ${err.body.toString()}`);
+        if (err.statusCode || err.statusMessage || err.body) {
+          log.err(`HTTP Promise error:`);
+          log.err(` \n Status Code: ${err.statusCode}`);
+          log.err(` \n Status Message: ${err.statusMessage}`);
+          log.err(` \n Response: ${err.body?.toString()}`);
+        } else {
+          log.err(`HTTP Promise error:`, err);
+        }
         (async () => {
           await (async function(msg) {
             utils.setOutputParameter("statusCode", msg.statusCode);
-            utils.setOutputParameter("response", msg.body.toString());
+            utils.setOutputParameter("response", msg.body?.toString());
           })(err);
           process.exit(1);
         })();

--- a/commands/http.js
+++ b/commands/http.js
@@ -160,8 +160,6 @@ module.exports = {
 
     new HTTPRetryRequest(config, reqURL, opts)
       .then(res => {
-        log.debug("res");
-        log.debug(res);
         log.debug(`statusCode: ${res.statusCode}`);
         utils.setOutputParameter("statusCode", JSON.stringify(res.statusCode));
         try {
@@ -202,8 +200,8 @@ module.exports = {
         }
         (async () => {
           await (async function(msg) {
-            utils.setOutputParameter("statusCode", msg.statusCode);
-            utils.setOutputParameter("response", msg.body?.toString());
+            utils.setOutputParameter("statusCode", msg?.statusCode ?? Buffer(0));
+            utils.setOutputParameter("response", msg?.body?.toString() ?? msg.message);
           })(err);
           process.exit(1);
         })();

--- a/commands/http.js
+++ b/commands/http.js
@@ -1,6 +1,5 @@
 const { log, utils } = require("@boomerang-io/worker-core");
 const HttpsProxyAgent = require("https-proxy-agent");
-const https = require("https");
 const URL = require("url");
 const fs = require("fs");
 const HTTPRetryRequest = require("../libs/HTTPRetryRequest");

--- a/libs/HTTPRetryRequest.js
+++ b/libs/HTTPRetryRequest.js
@@ -1,4 +1,5 @@
 const https = require("https");
+const http = require("http");
 const { log } = require("@boomerang-io/worker-core");
 const utilities = require("./utilities");
 // TODO: replace after node version is above 15.0.0
@@ -17,6 +18,7 @@ function HTTPRetryRequest(config, URL, options) {
   // process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
   let _self = this;
   _self.URL = URL;
+  _self.client = /^https:\/\//g.test(_self.URL) ? https : http;
   _self.options = options;
   // log.debug("HTTP Request Options:", _self.options);
   _self.config = { ...DEFAULTS, ...config }; // overwrite defaults
@@ -40,7 +42,7 @@ function HTTPRetryRequest(config, URL, options) {
   _self.buffer = Buffer.alloc(0);
 
   return new Promise((resolve, reject) => {
-    let requestInstance = https.request(_self.URL, _self.options, response => {
+    let requestInstance = _self.client.request(_self.URL, _self.options, response => {
       const innerStatusCode = response.statusCode.toString();
       const responseInstance = response
         .on("error", error => {


### PR DESCRIPTION
Closes #61

When other types of of request fails the original error is retuned and proper casting or optional chaining is required.