### PR TITLE
#69 Refactor HTTP task to incorporate different Success, Retry and Error codes

### DIFF
--- a/libs/HTTPRetryRequest.js
+++ b/libs/HTTPRetryRequest.js
@@ -7,8 +7,10 @@ const utilities = require("./utilities");
 const { checkForJson } = require("./../libs/utilities");
 
 let DEFAULTS = {
-  MAX_RETRIES: 5,
+  SUCCESS_CODES: "",
+  RETRY_CODES: "",
   ERROR_CODES: "",
+  MAX_RETRIES: 5,
   DELAY: 200,
   IS_ERROR: true
 };
@@ -23,6 +25,28 @@ function HTTPRetryRequest(config, URL, options) {
   // log.debug("HTTP Request Options:", _self.options);
   _self.config = { ...DEFAULTS, ...config }; // overwrite defaults
   // log.debug("HTTP Request Config:", _self.config);
+  if (_self.config.SUCCESS_CODES && _self.config.SUCCESS_CODES.length) {
+    // create pattern of /(5\d\d|4\d\d|9\d\d)/
+    // TODO: replace back with replaceAll after node version is above 15.0.0
+    // _self.config.SUCCESS_CODES = _self.config.SUCCESS_CODES.replaceAll(",", "|"); // replace sperator , with | for regex
+    _self.config.SUCCESS_CODES = _self.config.SUCCESS_CODES.replace(/\,/g, "|"); // replace sperator , with | for regex
+    _self.config.SUCCESS_CODES = _self.config.SUCCESS_CODES.toUpperCase(); // make uppercase (x -> X)
+    // TODO: replace back with replaceAll after node version is above 15.0.0
+    // _self.config.SUCCESS_CODES = _self.config.SUCCESS_CODES.replaceAll("X", "\\d"); // replace character X with \d for regex - represents a digit
+    _self.config.SUCCESS_CODES = _self.config.SUCCESS_CODES.replace(/X/g, "\\d"); // replace character X with \d for regex - represents a digit
+    _self.config.SUCCESS_CODES = new RegExp("(" + _self.config.SUCCESS_CODES + ")"); // wrap in () to have the alternative
+  }
+  if (_self.config.RETRY_CODES && _self.config.RETRY_CODES.length) {
+    // create pattern of /(5\d\d|4\d\d|9\d\d)/
+    // TODO: replace back with replaceAll after node version is above 15.0.0
+    // _self.config.RETRY_CODES = _self.config.RETRY_CODES.replaceAll(",", "|"); // replace sperator , with | for regex
+    _self.config.RETRY_CODES = _self.config.RETRY_CODES.replace(/\,/g, "|"); // replace sperator , with | for regex
+    _self.config.RETRY_CODES = _self.config.RETRY_CODES.toUpperCase(); // make uppercase (x -> X)
+    // TODO: replace back with replaceAll after node version is above 15.0.0
+    // _self.config.RETRY_CODES = _self.config.RETRY_CODES.replaceAll("X", "\\d"); // replace character X with \d for regex - represents a digit
+    _self.config.RETRY_CODES = _self.config.RETRY_CODES.replace(/X/g, "\\d"); // replace character X with \d for regex - represents a digit
+    _self.config.RETRY_CODES = new RegExp("(" + _self.config.RETRY_CODES + ")"); // wrap in () to have the alternative
+  }
   if (_self.config.ERROR_CODES && _self.config.ERROR_CODES.length) {
     // create pattern of /(5\d\d|4\d\d|9\d\d)/
     // TODO: replace back with replaceAll after node version is above 15.0.0
@@ -48,59 +72,64 @@ function HTTPRetryRequest(config, URL, options) {
         .on("error", error => {
           log.debug(`Retry onError #${_self.config.retryCount} HTTP Status Code: ${innerStatusCode} \n Status Message: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`);
           responseInstance.abort();
-          if (_self.config.ERROR_CODES && _self.config.ERROR_CODES.test(innerStatusCode) && _self.config.retryCount <= _self.config.MAX_RETRIES) {
-            if (!_self.config.IS_ERROR) {
-              // Success branch and one of the status codes is found, resolve with success
-              resolve({
-                statusCode: innerStatusCode,
-                body: Buffer.alloc(0) // empty body
-              });
-              return; // exit to avoid next call
-            }
+          if (_self.config.ERROR_CODES && _self.config.ERROR_CODES.test(innerStatusCode)) {
+            log.debug(`onError - user specific error reject.`);
+            reject(error);
+            return;
+          }
+          if (_self.config.SUCCESS_CODES && _self.config.SUCCESS_CODES.test(innerStatusCode)) {
+            // Success branch and one of the status codes is found, resolve with success
+            resolve({
+              statusCode: innerStatusCode,
+              body: Buffer.alloc(0) // empty body
+            });
+            return; // exit to avoid next call
+          }
+          if (_self.config.RETRY_CODES && _self.config.RETRY_CODES.test(innerStatusCode) && _self.config.retryCount <= _self.config.MAX_RETRIES) {
             setTimeout(timeOutRetry, _self.config.DELAY, _self.config, _self.URL, _self.options, resolve);
             // TODO: replace after node version is above 15.0.0
             // log.debug(`Retry onError #${_self.config.retryCount} next call.`);
             // resolve(setTimeoutPromise(_self.config.DELAY, new HTTPRetryRequest( _self.config, _self.URL, _self.options)));
-          } else {
-            log.debug(`onError #${_self.config.retryCount} reject.`);
-            // no more tries, just reject
-            reject(error);
+            return;
           }
+          log.debug(`onError - other error reject.`);
+          reject(error);
         })
         .on("data", chunk => (_self.buffer = Buffer.concat([_self.buffer, chunk])))
         .on("end", () => {
           log.debug(`Retry onEnd #${_self.config.retryCount} HTTP Status Code: ${innerStatusCode} \n Status Message: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`);
-          if (_self.config.ERROR_CODES && _self.config.ERROR_CODES.test(innerStatusCode) && _self.config.retryCount <= _self.config.MAX_RETRIES) {
-            if (!_self.config.IS_ERROR) {
-              // Success branch and one of the status codes is found, resolve with success
-              resolve({
-                statusCode: innerStatusCode,
-                body: _self.buffer
-              });
-              return; // exit to avoid next call
-            }
+          if (_self.config.ERROR_CODES && _self.config.ERROR_CODES.test(innerStatusCode)) {
+            log.debug(`onEnd - user specific error reject.\n StatusMessage: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`);
+            reject({
+              statusCode: innerStatusCode,
+              statusMessage: response.statusMessage,
+              body: _self.buffer
+            });
+          }
+          if (_self.config.SUCCESS_CODES && (_self.config.SUCCESS_CODES.test(innerStatusCode) || /2\d\d/g.test(innerStatusCode.toString()))) {
+            log.debug(`onEnd #${_self.config.retryCount} resolve.`);
+            // Success branch and one of the status codes is found, resolve with success
+            resolve({
+              statusCode: innerStatusCode,
+              body: _self.buffer
+            });
+            return; // exit to avoid next call
+          }
+          if (_self.config.RETRY_CODES && _self.config.RETRY_CODES.test(innerStatusCode) && _self.config.retryCount <= _self.config.MAX_RETRIES) {
             setTimeout(timeOutRetry, _self.config.DELAY, _self.config, _self.URL, _self.options, resolve);
             // TODO: replace after node version is above 15.0.0
-            // log.debug(`Retry onEnd #${_self.config.retryCount} next call.`);
+            // log.debug(`Retry onError #${_self.config.retryCount} next call.`);
             // resolve(setTimeoutPromise(_self.config.DELAY, new HTTPRetryRequest( _self.config, _self.URL, _self.options)));
-          } else {
-            log.debug(`onEnd #${_self.config.retryCount} resolve.`);
-            if (/2\d\d/g.test(innerStatusCode.toString())) {
-              resolve({
-                statusCode: innerStatusCode,
-                body: _self.buffer
-              });
-            } else {
-              // no more tries, just reject
-              log.debug(`onEnd reject \n StatusMessage: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`);
-              // reject(new Error(innerStatusCode, { cause: `StatusMessage: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`}));
-              reject({
-                statusCode: innerStatusCode,
-                statusMessage: response.statusMessage,
-                body: _self.buffer
-              });
-            }
+            return;
           }
+          // no more tries, just reject
+          log.debug(`onEnd reject \n StatusMessage: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`);
+          // reject(new Error(innerStatusCode, { cause: `StatusMessage: ${response.statusMessage.toString()} \n Response ${_self.buffer.toString()}.`}));
+          reject({
+            statusCode: innerStatusCode,
+            statusMessage: response.statusMessage,
+            body: _self.buffer
+          });
         });
     });
     requestInstance.on("error", err => {


### PR DESCRIPTION
Closes #69

Refactor the HTTP task to incorporate different Success , Retry and Error codes.
- HTTP response codes for Success -- default of 1xx,2xx or just standard http default
- HTTP response codes for Failure (validation to be mutually exclusive w/ letter a — default standard http
- HTTP response codes for Retry (validation mutually exclusive to both a and b) --- default none or 502/3;
- Retry count between 1 and 9
- Extend delay between retries up to 5 minutes (300000 milliseconds).
