### PR TITLE
fix: decode param to true empty string

### DIFF
--- a/commands/file.js
+++ b/commands/file.js
@@ -256,7 +256,7 @@ module.exports = {
       strict: true,
       reviver: function(key, value) {
         if (key != null && value == null) {
-          return '""';
+          return ""; 
         } else {
           //Returns all the lines
           return this.assert();


### PR DESCRIPTION
Closes #

Fixes errors when replacing parameters that have `null` values

#### Changelog

**New**

Nada

**Changed**

Default value for a null value is now an empty string instead of `'""'`

**Removed**

Nada

#### Testing / Reviewing

Test with replace params action
